### PR TITLE
Step 0N: Bootstrap backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+.env
+.venv/
+.uv/
+pytest.ini
+.pytest_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,42 @@
-# Project
+# Codex App
 
-This repository uses Codex automation with guards and CI.
-See docs/codex/README.md for details.
+This repository houses the backend service that Codex automation will grow step by step.
+The backend is implemented with FastAPI and packaged under `src/app`.
+
+## Getting started
+
+1. Create a virtual environment and activate it:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the project in editable mode with development dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## Running the API locally
+
+Launch the development server with Uvicorn:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The health endpoint is available at <http://127.0.0.1:8000/health> and returns service status metadata.
+
+## Tests and coverage
+
+Pytest is configured to collect coverage automatically with a minimum threshold of 85%.
+Simply run:
+
+```bash
+pytest
+```
+
+The default options produce a terminal coverage report and fail the run if thresholds are not met.
+
+## Operational docs
+
+Codex operating guides live under `docs/codex/`.
+Refer to `docs/codex/README.md` for automation rules and guard details.

--- a/docs/codex/last_output.json
+++ b/docs/codex/last_output.json
@@ -1,11 +1,14 @@
 {
-  "generated_at": "2025-09-22 05:37:43",
-  "summary": "bootstrap pack created",
+  "generated_at": "2025-09-22 05:50:00",
+  "summary": "Bootstrapped FastAPI backend skeleton with health endpoint and coverage-backed tests",
   "tests": {
-    "passed": 0,
+    "command": "pytest",
+    "passed": 2,
     "failed": 0
   },
   "duration_seconds": 0,
   "token_cost": null,
-  "diff": []
+  "diff": [
+    "Added pyproject configuration, FastAPI app, and README instructions for step 0N"
+  ]
 }

--- a/docs/codex/memory/decisions.jsonl
+++ b/docs/codex/memory/decisions.jsonl
@@ -1,0 +1,1 @@
+{"timestamp": "2025-09-22T05:48:02Z", "step": "0N", "decision": "Bootstrap FastAPI app skeleton with health endpoint to align with roadmap", "rationale": "Provides tested baseline satisfying coverage guard before future features"}

--- a/docs/codex/reflections.md
+++ b/docs/codex/reflections.md
@@ -1,1 +1,1 @@
-Last reflections (keep <= 200 words). Update this per step.
+Focused on building a clean baseline that meets guard expectations. Choosing a factory pattern early should make future configuration (DB, auth) simpler while keeping tests fast. Next time I will pre-create the virtual environment instead of installing globally to avoid pip warnings, but it did not block the run today.

--- a/docs/codex/todo_next.md
+++ b/docs/codex/todo_next.md
@@ -1,2 +1,3 @@
-- TODO 1
-- TODO 2
+1. Integrate guard scripts into CI and document guard workflow (step-01).
+2. Set up linting/type-check tooling to complement coverage gates.
+3. Draft initial database schema requirements for upcoming mission features.

--- a/docs/roadmap/step-0N.md
+++ b/docs/roadmap/step-0N.md
@@ -1,0 +1,25 @@
+# Step 0N - Backend bootstrap baseline
+
+## Context
+- The backend stack is FastAPI with SQLAlchemy, Alembic, and Pydantic, so the project needs a Python package layout that supports that stack from the start ([docs/codex/PROMPT.backend.step-template.md](../codex/PROMPT.backend.step-template.md)).
+- Guards enforce 70% global coverage and 60% on changed files, so the initial skeleton must ship with tests that satisfy those thresholds ([tools/guards/policy.toml](../../tools/guards/policy.toml)).
+- The auto-review checklist requires documenting public surfaces, which applies once we expose a health endpoint ([docs/codex/checklists/auto_review.md](../codex/checklists/auto_review.md)).
+
+## Objectives
+- Scaffold a `src/app` package with a FastAPI application factory and an `/health` endpoint returning service status metadata.
+- Provide pytest-based tests with coverage instrumentation that keep the baseline above guard thresholds.
+- Publish developer instructions for installing dependencies, running the server locally, and executing tests with coverage.
+
+## Tasks
+1. Add a `pyproject.toml` configured for a `codex-app` package under `src/`, including runtime dependencies (`fastapi`, `pydantic`, `uvicorn`) and dev dependencies (`pytest`, `pytest-cov`, `httpx`).
+2. Create `app/main.py` with a `create_app()` factory, module-level `app` instance, and router registration.
+3. Add `app/api/health.py` that defines the `/health` route and response schema.
+4. Implement pytest tests covering the factory and health endpoint behaviour.
+5. Configure pytest coverage defaults (fail-under >= 85%) via `pyproject.toml` or config file.
+6. Update `README.md` with setup, run, and test instructions.
+
+## Acceptance Criteria
+- `pytest` with coverage succeeds locally without additional flags.
+- Coverage thresholds meet or exceed policy (>= 85% overall from configuration).
+- `GET /health` responds with HTTP 200 and expected JSON payload in tests.
+- Documentation shows developers how to install dependencies, run the API, and execute tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codex-app"
+version = "0.1.0"
+description = "Codex backend service"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.110",
+    "pydantic>=2.5",
+    "uvicorn>=0.27",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+    "httpx>=0.25",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=app --cov-report=term-missing --cov-fail-under=85"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["app"]
+
+[tool.coverage.report]
+skip_empty = true

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,5 @@
+"""Core application package for the Codex backend."""
+
+from .main import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API router exports."""
+
+from .health import router as health_router
+
+__all__ = ["health_router"]

--- a/src/app/api/health.py
+++ b/src/app/api/health.py
@@ -1,0 +1,20 @@
+"""Health endpoint returning service metadata."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+router = APIRouter(tags=["health"])
+
+
+class HealthResponse(BaseModel):
+    """Response payload for the health check."""
+
+    status: str = Field(description="Overall service status indicator.")
+    service: str = Field(description="Identifier for the running service.")
+
+
+@router.get("/health", response_model=HealthResponse, summary="Service status check")
+def health_check() -> HealthResponse:
+    """Return a simple readiness indicator for liveness probes."""
+
+    return HealthResponse(status="ok", service="codex_app")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,19 @@
+"""Application factory for the Codex backend."""
+
+from fastapi import FastAPI
+
+from .api import health_router
+
+APP_TITLE = "Codex App"
+APP_VERSION = "0.1.0"
+
+
+def create_app() -> FastAPI:
+    """Instantiate the FastAPI application with core routes."""
+
+    app = FastAPI(title=APP_TITLE, version=APP_VERSION)
+    app.include_router(health_router)
+    return app
+
+
+app = create_app()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,23 @@
+"""Tests for the health endpoint and application factory."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app, create_app
+
+
+def test_health_endpoint_returns_expected_payload() -> None:
+    """The /health endpoint should respond with a deterministic payload."""
+
+    client = TestClient(create_app())
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "codex_app"}
+
+
+def test_module_level_app_is_reusable() -> None:
+    """The global app instance should also expose the health endpoint."""
+
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
Summary:
- add a FastAPI application factory with a /health endpoint and reusable module-level app instance
- configure pyproject dependencies plus pytest coverage defaults, and document setup/test flows in the README
- author roadmap step-0N so the new baseline is explicitly tracked for future steps

Checks:
- [x] Ref: docs/roadmap/step-0N.md
- [x] Auto-review checklist satisfied
- [x] Coverage meets thresholds

Ref: docs/roadmap/step-0N.md

------
https://chatgpt.com/codex/tasks/task_e_68d0e1e4a9cc83309b6f0ba0be1aa563