### PR TITLE
chore(ci): remove invalid PowerShell action and run guards with pwsh

### DIFF
--- a/.github/workflows/codex_ci.yml
+++ b/.github/workflows/codex_ci.yml
@@ -48,6 +48,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
       - name: Run guard suite
-        uses: PowerShell/PowerShell@v1
-        with:
-          inlineScript: ./tools/guards/run_all_guards.ps1
+        shell: pwsh
+        run: ./tools/guards/run_all_guards.ps1


### PR DESCRIPTION
## Summary
- remove the invalid PowerShell/PowerShell action from the guard job
- execute the guard suite directly with the preinstalled pwsh shell on Ubuntu runners

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d0eac4abfc83309b6f29733ee90838