### PR TITLE
chore(guards): enforce last_output.json requirements

### DIFF
--- a/.githooks/pre-commit.ps1
+++ b/.githooks/pre-commit.ps1
@@ -1,0 +1,40 @@
+# Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) {
+    exit 0
+}
+
+$target = Join-Path $repoRoot "docs/codex/last_output.json"
+if (-not (Test-Path $target)) {
+    Write-Host "ERROR: docs/codex/last_output.json is missing."
+    Write-Host 'Hint: pwsh -File tools/codex/ensure_last_output.ps1 -Step "NN" -Title "Your title" -Summary "Your summary" -Status success'
+    exit 1
+}
+
+try {
+    $json = Get-Content -Path $target -Raw | ConvertFrom-Json
+} catch {
+    Write-Host "ERROR: docs/codex/last_output.json is not valid JSON."
+    exit 1
+}
+
+$required = @("version", "step", "title", "summary", "status", "timestamp")
+$missing = @()
+foreach ($name in $required) {
+    $hasProperty = $json.PSObject.Properties.Name -contains $name
+    $value = $json.$name
+    if (-not $hasProperty -or [string]::IsNullOrWhiteSpace([string]$value)) {
+        $missing += $name
+    }
+}
+
+if ($missing.Count -gt 0) {
+    Write-Host "ERROR: docs/codex/last_output.json missing keys: $($missing -join ", ")."
+    Write-Host 'Hint: pwsh -File tools/codex/ensure_last_output.ps1 -Step "NN" -Title "Your title" -Summary "Your summary"'
+    exit 1
+}
+
+exit 0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,25 @@
-# All pull requests must reference the roadmap
+# Pull Request Template
+
 Ref: docs/roadmap/step-XX.md
 
 ## Checklist
-- [ ] Tests passent en CI
-- [ ] Lint / typecheck passent
-- [ ] Documentation mise à jour si nécessaire
-- [ ] Commit message suit Conventional Commits
-- [ ] PR contient la ligne Ref: docs/roadmap/step-XX.md
+- [ ] Tests pass in CI
+- [ ] Lint and type checks pass
+- [ ] Documentation updated if needed
+- [ ] Commit message follows Conventional Commits
+- [ ] PR description includes Ref: docs/roadmap/step-XX.md
+- [ ] docs/codex/last_output.json present with a non-empty "summary"
 
 ## Description
-Expliquez clairement le problème et la solution proposée.
+Clearly explain the problem and the proposed solution.
 
 ## Why
-Pourquoi ce changement est nécessaire.
+Describe why this change is necessary.
 
 ## What changed
-Détail des fichiers ou workflows modifiés.
+List the files, workflows, or guards that were updated.
+
+### Quick command to generate last_output.json
+```
+pwsh -File tools/codex/ensure_last_output.ps1 -Step "XX" -Title "Step XX - Snapshot" -Summary "Short human summary." -Status "success"
+```

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -1,0 +1,80 @@
+name: Guards Precheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pre-guards-last-output:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up PowerShell
+        uses: PowerShell/PowerShell@v1
+        with:
+          version: '7.4.x'
+      - name: Ensure last_output snapshot
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $target = "docs/codex/last_output.json"
+          $required = @("version", "step", "title", "summary", "status", "timestamp")
+          $hadFile = Test-Path $target
+          $originalContent = $null
+          $originalIssues = @()
+          $originalJson = $null
+
+          if ($hadFile) {
+            $originalContent = Get-Content -Path $target -Raw
+            try {
+              $originalJson = $originalContent | ConvertFrom-Json
+            } catch {
+              $originalIssues += "invalid json"
+            }
+
+            if ($originalJson) {
+              foreach ($key in $required) {
+                $hasProperty = $originalJson.PSObject.Properties.Name -contains $key
+                $value = $originalJson.$key
+                if (-not $hasProperty -or [string]::IsNullOrWhiteSpace([string]$value)) {
+                  $originalIssues += $key
+                }
+              }
+            }
+          } else {
+            $originalIssues += "missing"
+          }
+
+          try {
+            pwsh -File tools/codex/ensure_last_output.ps1 -Step "${{ github.ref_name }}" -Title "Auto ensure last_output" -Summary "CI ensure step" -Status "pending"
+            $generatedJson = Get-Content -Path $target -Raw | ConvertFrom-Json
+            foreach ($key in $required) {
+              $hasProperty = $generatedJson.PSObject.Properties.Name -contains $key
+              $value = $generatedJson.$key
+              if (-not $hasProperty -or [string]::IsNullOrWhiteSpace([string]$value)) {
+                throw "Generated last_output.json missing key: $key"
+              }
+            }
+          } finally {
+            if ($hadFile -and $null -ne $originalContent) {
+              Set-Content -Encoding Ascii -Path $target -Value $originalContent
+            } elseif (-not $hadFile -and (Test-Path $target)) {
+              Remove-Item $target -Force
+            }
+          }
+
+          if (-not $hadFile) {
+            Write-Error "docs/codex/last_output.json is missing from the branch. Run the ensure script locally and commit the result."
+            exit 1
+          }
+
+          if ($originalIssues.Count -gt 0) {
+            $issueList = $originalIssues -join ", "
+            Write-Error "docs/codex/last_output.json has issues: $issueList. Run the ensure script locally and commit the result."
+            exit 1
+          }
+
+          Write-Host "docs/codex/last_output.json already satisfies the minimal schema."

--- a/docs/codex/SCHEMA.last_output.json
+++ b/docs/codex/SCHEMA.last_output.json
@@ -1,0 +1,33 @@
+{
+  "description": "Minimal documentation for docs/codex/last_output.json",
+  "version": 1,
+  "required_keys": [
+    "version",
+    "step",
+    "title",
+    "summary",
+    "status",
+    "timestamp"
+  ],
+  "optional_keys": [
+    "outputs"
+  ],
+  "notes": [
+    "All values must be ASCII characters only.",
+    "Timestamp must be UTC in ISO 8601 format with a trailing Z.",
+    "Outputs is an optional array of strings for extra context."
+  ],
+  "example": {
+    "version": "1",
+    "step": "03",
+    "title": "Step 03 - Guards Passing Snapshot",
+    "summary": "All guards green and summary present.",
+    "status": "success",
+    "timestamp": "2025-01-01T00:00:00Z",
+    "outputs": [
+      "pytest ok",
+      "lint ok",
+      "guards ok"
+    ]
+  }
+}

--- a/docs/codex/last_output.json
+++ b/docs/codex/last_output.json
@@ -1,25 +1,8 @@
 {
-  "step": "step-03",
-  "files_created": [
-    "docs/roadmap/step-03.md",
-    "src/app/api/routes/__init__.py",
-    "src/app/api/routes/health.py",
-    "src/app/api/routes/version.py",
-    "src/app/core/config.py"
-  ],
-  "files_modified": [
-    "src/app/api/__init__.py",
-    "src/app/settings.py",
-    "tests/test_health.py",
-    "tests/test_version.py"
-  ],
-  "tests": {
-    "pytest -q": "pass",
-    "pytest --cov=src --cov-report=term-missing": "pass"
-  },
-  "ci": {
-    "status": "pending",
-    "details": "GitHub Actions backend-tests workflow expected to pass."
-  },
-  "notes": "Added health and version endpoints with pyproject-based version resolution and supporting tests."
+  "version": "1",
+  "step": "03",
+  "title": "Step 03 - Guards Snapshot",
+  "summary": "All guards green.",
+  "status": "success",
+  "timestamp": "2025-09-22T11:13:56Z"
 }

--- a/docs/codex/last_output.sample.json
+++ b/docs/codex/last_output.sample.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "step": "XX",
+  "title": "Step XX - Snapshot",
+  "summary": "Short summary of the latest progress.",
+  "status": "success",
+  "timestamp": "2025-01-01T00:00:00Z"
+}

--- a/tools/codex/ensure_last_output.ps1
+++ b/tools/codex/ensure_last_output.ps1
@@ -1,0 +1,71 @@
+# Requires -Version 7.0
+param(
+    [Parameter(Mandatory=$true)][string]$Step,
+    [Parameter(Mandatory=$true)][string]$Title,
+    [Parameter(Mandatory=$true)][string]$Summary,
+    [string]$Status = "success",
+    [string[]]$Outputs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-NonEmpty {
+    param(
+        [string]$Name,
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "Parameter '$Name' cannot be empty."
+    }
+}
+
+Assert-NonEmpty -Name "Step" -Value $Step
+Assert-NonEmpty -Name "Title" -Value $Title
+Assert-NonEmpty -Name "Summary" -Value $Summary
+Assert-NonEmpty -Name "Status" -Value $Status
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$docDir = Join-Path $repoRoot "docs/codex"
+if (-not (Test-Path $docDir)) {
+    New-Item -ItemType Directory -Force -Path $docDir | Out-Null
+}
+
+$timestamp = (Get-Date -AsUTC).ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+$payload = [ordered]@{
+    version = "1"
+    step = $Step
+    title = $Title
+    summary = $Summary
+    status = $Status
+    timestamp = $timestamp
+}
+
+if ($Outputs -and $Outputs.Count -gt 0) {
+    $payload.outputs = $Outputs
+}
+
+$json = $payload | ConvertTo-Json -Depth 6
+$asciiBuilder = New-Object System.Text.StringBuilder
+foreach ($ch in $json.ToCharArray()) {
+    $code = [int][char]$ch
+    if ($code -ge 0 -and $code -le 127) {
+        [void]$asciiBuilder.Append($ch)
+    } else {
+        [void]$asciiBuilder.Append("?")
+    }
+}
+
+$outFile = Join-Path $docDir "last_output.json"
+Set-Content -Encoding Ascii -Path $outFile -Value $asciiBuilder.ToString()
+
+try {
+    Get-Content -Path $outFile -Raw | ConvertFrom-Json | Out-Null
+} catch {
+    Write-Error "Invalid JSON written to $outFile"
+    exit 1
+}
+
+Write-Host "last_output.json updated at $outFile"

--- a/tools/guards/commit_guard.ps1
+++ b/tools/guards/commit_guard.ps1
@@ -1,19 +1,37 @@
-
 Param(
   [switch]$Strict
 )
 . "$PSScriptRoot/utils.ps1"
 
-$jsonPath = "docs/codex/last_output.json"
-if (-not (Test-Path $jsonPath)) {
-  Exit-Fail "Missing docs/codex/last_output.json"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$lastOutputPath = Join-Path $repoRoot "docs/codex/last_output.json"
+$hint = 'Hint: pwsh -File tools/codex/ensure_last_output.ps1 -Step "NN" -Title "Title" -Summary "Short summary"'
+
+if (-not (Test-Path $lastOutputPath)) {
+  Write-Host $hint
+  Exit-Fail "commit_guard: missing docs/codex/last_output.json"
 }
 
 try {
-  $o = Get-Content $jsonPath -Raw | ConvertFrom-Json
-  if (-not $o.summary) { Exit-Fail "last_output.json missing 'summary'" }
+  $json = Get-Content -Path $lastOutputPath -Raw | ConvertFrom-Json
 } catch {
-  Exit-Fail "Invalid JSON in last_output.json"
+  Write-Host $hint
+  Exit-Fail "commit_guard: invalid JSON in docs/codex/last_output.json"
+}
+
+$required = @("version", "step", "title", "summary", "status", "timestamp")
+$missing = @()
+foreach ($name in $required) {
+  $hasProperty = $json.PSObject.Properties.Name -contains $name
+  $value = $json.$name
+  if (-not $hasProperty -or [string]::IsNullOrWhiteSpace([string]$value)) {
+    $missing += $name
+  }
+}
+
+if ($missing.Count -gt 0) {
+  Write-Host $hint
+  Exit-Fail ("commit_guard: docs/codex/last_output.json missing: " + ($missing -join ", "))
 }
 
 Write-Host "commit_guard: OK"

--- a/tools/guards/run_all_guards.ps1
+++ b/tools/guards/run_all_guards.ps1
@@ -37,6 +37,10 @@ foreach ($guard in $guards) {
   Write-Host "Running $guard..."
   & $path
   if ($LASTEXITCODE -ne 0) {
+    if ($guard -eq "commit_guard.ps1") {
+      Write-Host "commit_guard detected an issue with docs/codex/last_output.json."
+      Write-Host 'Run: pwsh -File tools/codex/ensure_last_output.ps1 -Step "NN" -Title "Title" -Summary "Short summary"'
+    }
     $guardExit = $LASTEXITCODE
     break
   }


### PR DESCRIPTION
## Summary
- add a PowerShell helper that emits ASCII-only docs/codex/last_output.json along with schema and sample docs
- enforce last_output.json validation with a pre-commit hook, stricter commit guard messaging, and a pre-check workflow step
- refresh the PR template to call out the summary requirement and provide a quick ensure_last_output command

## Testing
- pwsh -NoLogo -NoProfile -File tools/guards/run_all_guards.ps1

------
https://chatgpt.com/codex/tasks/task_e_68d12dcb3f848330a3ea33b62519324f