### PR TITLE
feat(missions): add mission domain model

### DIFF
--- a/alembic/versions/20240207_02_create_missions_table.py
+++ b/alembic/versions/20240207_02_create_missions_table.py
@@ -1,0 +1,75 @@
+"""Create missions table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240207_02"
+down_revision = "20240207_01"
+branch_labels = None
+depends_on = None
+
+
+MISSION_STATUS_VALUES = (
+    "draft",
+    "scheduled",
+    "in_progress",
+    "completed",
+    "cancelled",
+)
+
+
+def upgrade() -> None:
+    mission_status_enum = sa.Enum(  # type: ignore[arg-type]
+        *MISSION_STATUS_VALUES,
+        name="missionstatus",
+        native_enum=False,
+        length=50,
+    )
+    op.create_table(
+        "missions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("code", sa.String(length=40), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            mission_status_enum,
+            nullable=False,
+            server_default=sa.text("'draft'"),
+        ),
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ends_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("owner_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            server_onupdate=sa.func.now(),
+        ),
+        sa.UniqueConstraint("code", name="uq_missions_code"),
+        sa.CheckConstraint(
+            "(starts_at IS NULL OR ends_at IS NULL) OR starts_at <= ends_at",
+            name="ck_missions_schedule_order",
+        ),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["users.id"],
+            name="fk_missions_owner_id_users",
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index("ix_missions_code", "missions", ["code"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_missions_code", table_name="missions")
+    op.drop_table("missions")

--- a/docs/codex/PROMPT.backend.step-04.md
+++ b/docs/codex/PROMPT.backend.step-04.md
@@ -1,0 +1,10 @@
+SYSTEM
+You are CODEx. Execute deterministically. ASCII-only outputs.
+
+USER
+Implement Roadmap Step 04 as described in docs/roadmap/step-04.md. Use Windows-first PowerShell scripts where relevant.
+
+ACCEPTANCE
+* CI green, coverage unchanged or improved, guards satisfied.
+* PR body contains exact line:
+  Ref: docs/roadmap/step-04.md

--- a/docs/roadmap/step-04.md
+++ b/docs/roadmap/step-04.md
@@ -1,0 +1,34 @@
+# Roadmap - Step 04
+
+Context
+
+* Operations need a way to plan and monitor missions. The backend only persists auth data today, so we must introduce a first-class
+  mission record with scheduling metadata and status tracking.
+* Step 04 focuses on the domain model only. API handlers and background automation will arrive in later steps once we stabilise
+  the schema.
+
+Goals
+
+* [ ] Introduce a `Mission` SQLAlchemy model that stores business identifiers, scheduling windows, audit timestamps, and status.
+* [ ] Enforce controlled status transitions via domain helpers so that missions can only progress forward.
+* [ ] Provide Pydantic schemas to validate create/update payloads for future API work.
+* [ ] Generate an Alembic migration that creates the `missions` table with integrity constraints.
+
+Deliverables
+
+* `src/app/models/mission.py` exporting `Mission` and `MissionStatus` plus helper methods.
+* `src/app/models/__init__.py` re-export updated domain objects.
+* `src/app/schemas/mission.py` with create/update/read contracts and status validation helpers.
+* Alembic migration adding the `missions` table and schedule check constraint.
+* Tests covering mission persistence, uniqueness, scheduling guards, and status transitions.
+
+Validation
+
+* CI: all guards, lints, tests green.
+* Include the exact line below in the PR that completes this step:
+  Ref: docs/roadmap/step-04.md
+* New tests prove the transition matrix and constraint behaviour.
+
+Notes
+
+* Keep scripts Windows-friendly; prefer PowerShell for developer utilities when scripting is required.

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,7 +1,8 @@
 """SQLAlchemy model exports."""
 
+from .mission import Mission, MissionStatus
 from .permission import Permission
 from .role import Role
 from .user import User
 
-__all__ = ["Permission", "Role", "User"]
+__all__ = ["Mission", "MissionStatus", "Permission", "Role", "User"]

--- a/src/app/models/mission.py
+++ b/src/app/models/mission.py
@@ -1,0 +1,112 @@
+"""Mission domain model with status transitions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import ClassVar, TYPE_CHECKING
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Enum as SQLEnum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..db import Base
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .user import User
+
+
+class MissionStatus(str, Enum):
+    """Possible lifecycle states for a mission."""
+
+    DRAFT = "draft"
+    SCHEDULED = "scheduled"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class Mission(Base):
+    """Mission persisted entity representing planned work."""
+
+    __tablename__ = "missions"
+    __table_args__ = (
+        UniqueConstraint("code", name="uq_missions_code"),
+        CheckConstraint(
+            "(starts_at IS NULL OR ends_at IS NULL) OR starts_at <= ends_at",
+            name="ck_missions_schedule_order",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    code: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    status: Mapped[MissionStatus] = mapped_column(
+        SQLEnum(MissionStatus, native_enum=False, length=50),
+        nullable=False,
+        default=MissionStatus.DRAFT,
+    )
+    starts_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    ends_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    owner_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    owner: Mapped["User | None"] = relationship("User", backref="missions")
+
+    _TRANSITIONS: ClassVar[dict[MissionStatus, set[MissionStatus]]] = {
+        MissionStatus.DRAFT: {MissionStatus.SCHEDULED, MissionStatus.CANCELLED},
+        MissionStatus.SCHEDULED: {
+            MissionStatus.IN_PROGRESS,
+            MissionStatus.CANCELLED,
+        },
+        MissionStatus.IN_PROGRESS: {
+            MissionStatus.COMPLETED,
+            MissionStatus.CANCELLED,
+        },
+        MissionStatus.COMPLETED: set(),
+        MissionStatus.CANCELLED: set(),
+    }
+
+    def can_transition_to(self, new_status: MissionStatus) -> bool:
+        """Return True when the transition is allowed from the current status."""
+
+        if new_status == self.status:
+            return True
+        return new_status in self._TRANSITIONS[self.status]
+
+    def transition_to(self, new_status: MissionStatus) -> None:
+        """Update mission status if the transition is valid, otherwise raise."""
+
+        if new_status == self.status:
+            return
+        if not self.can_transition_to(new_status):
+            raise ValueError(
+                f"Cannot transition mission {self.code} from {self.status.value} to {new_status.value}"
+            )
+        self.status = new_status
+
+
+__all__ = ["Mission", "MissionStatus"]

--- a/src/app/schemas/__init__.py
+++ b/src/app/schemas/__init__.py
@@ -1,9 +1,14 @@
 """Pydantic schema exports."""
 
+from .mission import MissionBase, MissionCreate, MissionRead, MissionUpdate
 from .token import AccessToken, RefreshRequest, TokenPair, TokenPayload
 from .user import UserBase, UserCreate, UserLogin, UserRead
 
 __all__ = [
+    "MissionBase",
+    "MissionCreate",
+    "MissionRead",
+    "MissionUpdate",
     "AccessToken",
     "RefreshRequest",
     "TokenPair",

--- a/src/app/schemas/mission.py
+++ b/src/app/schemas/mission.py
@@ -1,0 +1,77 @@
+"""Pydantic schemas for mission data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+from app.models import MissionStatus
+
+
+class MissionBase(BaseModel):
+    """Common fields shared by mission payloads."""
+
+    code: str = Field(min_length=3, max_length=40, pattern=r"^[A-Z0-9-]+$")
+    title: str = Field(min_length=1, max_length=255)
+    summary: str | None = Field(default=None, max_length=2000)
+    starts_at: datetime | None = None
+    ends_at: datetime | None = None
+
+    @field_validator("ends_at")
+    @classmethod
+    def _validate_schedule(cls, ends_at: datetime | None, values: dict[str, object]) -> datetime | None:
+        """Ensure end date is not before the start date when both are provided."""
+
+        start = values.get("starts_at")
+        if start and ends_at and ends_at < start:
+            raise ValueError("ends_at must be greater than or equal to starts_at")
+        return ends_at
+
+
+class MissionCreate(MissionBase):
+    """Payload for creating a mission record."""
+
+    status: MissionStatus = MissionStatus.DRAFT
+    owner_id: int | None = None
+
+
+class MissionUpdate(BaseModel):
+    """Payload for updating mutable mission fields."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    summary: str | None = Field(default=None, max_length=2000)
+    starts_at: datetime | None = None
+    ends_at: datetime | None = None
+    status: MissionStatus | None = None
+    owner_id: int | None = None
+
+    @field_validator("ends_at")
+    @classmethod
+    def _validate_schedule(cls, ends_at: datetime | None, values: dict[str, object]) -> datetime | None:
+        start = values.get("starts_at")
+        if start and ends_at and ends_at < start:
+            raise ValueError("ends_at must be greater than or equal to starts_at")
+        return ends_at
+
+
+class MissionRead(MissionBase):
+    """Public representation of a mission."""
+
+    id: int
+    status: MissionStatus
+    owner_id: int | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+__all__ = [
+    "MissionBase",
+    "MissionCreate",
+    "MissionUpdate",
+    "MissionRead",
+]

--- a/tests/test_mission_model.py
+++ b/tests/test_mission_model.py
@@ -1,0 +1,74 @@
+"""Tests for the Mission domain model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models import Mission, MissionStatus
+
+
+def test_create_mission_defaults(db_session):
+    mission = Mission(code="MSN-001", title="First mission")
+    db_session.add(mission)
+    db_session.commit()
+    db_session.refresh(mission)
+
+    assert mission.status is MissionStatus.DRAFT
+    assert mission.created_at is not None
+    assert mission.updated_at is not None
+    assert mission.can_transition_to(MissionStatus.SCHEDULED)
+
+
+def test_mission_unique_code_enforced(db_session):
+    first = Mission(code="MSN-002", title="Unique code")
+    second = Mission(code="MSN-002", title="Duplicate code")
+    db_session.add_all([first, second])
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+def test_mission_schedule_constraint(db_session):
+    starts_at = datetime.now(tz=timezone.utc)
+    ends_at = starts_at - timedelta(hours=1)
+    mission = Mission(
+        code="MSN-003",
+        title="Backwards schedule",
+        starts_at=starts_at,
+        ends_at=ends_at,
+    )
+    db_session.add(mission)
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+def test_mission_status_transitions(db_session):
+    mission = Mission(code="MSN-004", title="Transition control")
+    db_session.add(mission)
+    db_session.commit()
+    db_session.refresh(mission)
+
+    assert mission.can_transition_to(MissionStatus.DRAFT)
+    mission.transition_to(MissionStatus.DRAFT)
+    db_session.commit()
+    db_session.refresh(mission)
+    assert mission.status is MissionStatus.DRAFT
+
+    mission.transition_to(MissionStatus.SCHEDULED)
+    db_session.commit()
+    db_session.refresh(mission)
+    assert mission.status is MissionStatus.SCHEDULED
+
+    mission.transition_to(MissionStatus.IN_PROGRESS)
+    db_session.commit()
+    db_session.refresh(mission)
+    assert mission.status is MissionStatus.IN_PROGRESS
+
+    with pytest.raises(ValueError):
+        mission.transition_to(MissionStatus.DRAFT)


### PR DESCRIPTION
## Summary
- add mission status enum and mission model with transition helpers
- provide mission pydantic schemas and alembic migration
- cover mission persistence and transitions with dedicated tests

Ref: docs/roadmap/step-04.md

------
https://chatgpt.com/codex/tasks/task_e_68d13474b4848330bf1fc825f7025330