### PR TITLE
chore(guards): add param blocks and strict propagation for commit_guard and wrapper

### DIFF
--- a/tools/guards/run_all_guards.ps1
+++ b/tools/guards/run_all_guards.ps1
@@ -9,14 +9,10 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3
 
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
-$commonArgs = @{}
-if ($Strict) {
-    $commonArgs.Strict = $true
-}
 
 function Run-Step($name, $script) {
     Write-Host ("Running {0}..." -f $name)
-    & $script @commonArgs
+    & $script @script:PSBoundParameters
     if ($LASTEXITCODE -ne 0) { throw ("{0} failed." -f $name) }
 }
 


### PR DESCRIPTION
## Summary
- ensure the guard wrapper forwards script parameters by invoking child guards with the script-level bound parameters

## Testing
- PR_BODY='Ref: docs/roadmap/step-04.md' pwsh -File tools/guards/commit_guard.ps1 --strict
- PR_BODY='Ref: docs/roadmap/step-04.md' pwsh -File tools/guards/run_all_guards.ps1 --strict

------
https://chatgpt.com/codex/tasks/task_e_68d15397479883308f39f30b30108d80