### PR TITLE
Add mission model, schemas, migration, and tests

### DIFF
--- a/alembic/versions/20240207_02_create_missions_table.py
+++ b/alembic/versions/20240207_02_create_missions_table.py
@@ -5,71 +5,65 @@ from __future__ import annotations
 from alembic import op
 import sqlalchemy as sa
 
+
 revision = "20240207_02"
 down_revision = "20240207_01"
 branch_labels = None
 depends_on = None
 
 
-MISSION_STATUS_VALUES = (
-    "draft",
-    "scheduled",
-    "in_progress",
-    "completed",
-    "cancelled",
+MISSION_STATUSES = (
+    "DRAFT",
+    "PLANNED",
+    "CONFIRMED",
+    "IN_PROGRESS",
+    "DONE",
+    "CANCELED",
 )
 
 
 def upgrade() -> None:
-    mission_status_enum = sa.Enum(  # type: ignore[arg-type]
-        *MISSION_STATUS_VALUES,
-        name="missionstatus",
+    mission_status_enum = sa.Enum(
+        *MISSION_STATUSES,
+        name="mission_status",
         native_enum=False,
-        length=50,
+        validate_strings=True,
     )
     op.create_table(
         "missions",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("code", sa.String(length=40), nullable=False),
-        sa.Column("title", sa.String(length=255), nullable=False),
-        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=False), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=False), nullable=False),
         sa.Column(
             "status",
             mission_status_enum,
             nullable=False,
-            server_default=sa.text("'draft'"),
+            server_default=sa.text("'DRAFT'"),
         ),
-        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("ends_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("owner_id", sa.Integer(), nullable=True),
+        sa.Column("notes", sa.String(length=2000), nullable=True),
         sa.Column(
             "created_at",
-            sa.DateTime(timezone=True),
+            sa.DateTime(timezone=False),
             nullable=False,
-            server_default=sa.func.now(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
         sa.Column(
             "updated_at",
-            sa.DateTime(timezone=True),
+            sa.DateTime(timezone=False),
             nullable=False,
-            server_default=sa.func.now(),
-            server_onupdate=sa.func.now(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
-        sa.UniqueConstraint("code", name="uq_missions_code"),
-        sa.CheckConstraint(
-            "(starts_at IS NULL OR ends_at IS NULL) OR starts_at <= ends_at",
-            name="ck_missions_schedule_order",
-        ),
-        sa.ForeignKeyConstraint(
-            ["owner_id"],
-            ["users.id"],
-            name="fk_missions_owner_id_users",
-            ondelete="SET NULL",
-        ),
+        sa.CheckConstraint("start_time < end_time", name="ck_missions_time_range"),
     )
-    op.create_index("ix_missions_code", "missions", ["code"], unique=False)
+    op.create_index(
+        "ix_missions_time_range",
+        "missions",
+        ["start_time", "end_time"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_missions_code", table_name="missions")
+    op.drop_index("ix_missions_time_range", table_name="missions")
     op.drop_table("missions")

--- a/docs/roadmap/step-04.md
+++ b/docs/roadmap/step-04.md
@@ -9,18 +9,18 @@ Context
 
 Goals
 
-* [ ] Introduce a `Mission` SQLAlchemy model that stores business identifiers, scheduling windows, audit timestamps, and status.
-* [ ] Enforce controlled status transitions via domain helpers so that missions can only progress forward.
-* [ ] Provide Pydantic schemas to validate create/update payloads for future API work.
-* [ ] Generate an Alembic migration that creates the `missions` table with integrity constraints.
+* [x] Introduce a `Mission` SQLAlchemy model that stores a UUID identifier, scheduling window, audit timestamps, notes, and status.
+* [x] Enforce controlled status transitions via domain helpers so that missions can only progress forward.
+* [x] Provide Pydantic schemas to validate create/update payloads for future API work.
+* [x] Generate an Alembic migration that creates the `missions` table with integrity constraints.
 
 Deliverables
 
-* `src/app/models/mission.py` exporting `Mission` and `MissionStatus` plus helper methods.
+* `src/app/models/mission.py` exporting `Mission` and `MissionStatus` plus helper methods for transitions.
 * `src/app/models/__init__.py` re-export updated domain objects.
-* `src/app/schemas/mission.py` with create/update/read contracts and status validation helpers.
-* Alembic migration adding the `missions` table and schedule check constraint.
-* Tests covering mission persistence, uniqueness, scheduling guards, and status transitions.
+* `src/app/schemas/mission.py` with create/update/read contracts and schedule validation helpers.
+* Alembic migration adding the `missions` table, enforcing the time window, and indexing `start_time`/`end_time`.
+* Tests covering mission persistence, scheduling guards, and status transitions.
 
 Validation
 

--- a/tests/test_mission_model.py
+++ b/tests/test_mission_model.py
@@ -1,17 +1,27 @@
-"""Tests for the Mission domain model."""
+"""Tests for the Mission model and transitions."""
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 
 from app.models import Mission, MissionStatus
+from app.schemas.mission import MissionCreate, MissionUpdate
 
 
-def test_create_mission_defaults(db_session):
-    mission = Mission(code="MSN-001", title="First mission")
+def make_times() -> tuple[datetime, datetime]:
+    start = datetime.now(tz=UTC).replace(tzinfo=None)
+    end = start + timedelta(hours=2)
+    return start, end
+
+
+def test_mission_persists_defaults(db_session):
+    start, end = make_times()
+    mission = Mission(title="Inspect site", start_time=start, end_time=end)
+
     db_session.add(mission)
     db_session.commit()
     db_session.refresh(mission)
@@ -19,28 +29,12 @@ def test_create_mission_defaults(db_session):
     assert mission.status is MissionStatus.DRAFT
     assert mission.created_at is not None
     assert mission.updated_at is not None
-    assert mission.can_transition_to(MissionStatus.SCHEDULED)
+    assert mission.can_transition_to(MissionStatus.PLANNED)
 
 
-def test_mission_unique_code_enforced(db_session):
-    first = Mission(code="MSN-002", title="Unique code")
-    second = Mission(code="MSN-002", title="Duplicate code")
-    db_session.add_all([first, second])
-
-    with pytest.raises(IntegrityError):
-        db_session.commit()
-    db_session.rollback()
-
-
-def test_mission_schedule_constraint(db_session):
-    starts_at = datetime.now(tz=timezone.utc)
-    ends_at = starts_at - timedelta(hours=1)
-    mission = Mission(
-        code="MSN-003",
-        title="Backwards schedule",
-        starts_at=starts_at,
-        ends_at=ends_at,
-    )
+def test_mission_time_window_enforced(db_session):
+    start = datetime.now(tz=UTC).replace(tzinfo=None)
+    mission = Mission(title="Invalid window", start_time=start, end_time=start)
     db_session.add(mission)
 
     with pytest.raises(IntegrityError):
@@ -48,27 +42,58 @@ def test_mission_schedule_constraint(db_session):
     db_session.rollback()
 
 
-def test_mission_status_transitions(db_session):
-    mission = Mission(code="MSN-004", title="Transition control")
+def test_mission_happy_path_transitions(db_session):
+    start, end = make_times()
+    mission = Mission(title="Deployment", start_time=start, end_time=end)
     db_session.add(mission)
     db_session.commit()
     db_session.refresh(mission)
 
-    assert mission.can_transition_to(MissionStatus.DRAFT)
-    mission.transition_to(MissionStatus.DRAFT)
-    db_session.commit()
-    db_session.refresh(mission)
-    assert mission.status is MissionStatus.DRAFT
+    mission.transition_to(MissionStatus.PLANNED)
+    mission.transition_to(MissionStatus.CONFIRMED)
+    mission.start()
+    mission.finish()
 
-    mission.transition_to(MissionStatus.SCHEDULED)
     db_session.commit()
     db_session.refresh(mission)
-    assert mission.status is MissionStatus.SCHEDULED
 
-    mission.transition_to(MissionStatus.IN_PROGRESS)
+    assert mission.status is MissionStatus.DONE
+
+
+def test_mission_invalid_transition_raises(db_session):
+    start, end = make_times()
+    mission = Mission(title="Cannot skip", start_time=start, end_time=end)
+    db_session.add(mission)
     db_session.commit()
     db_session.refresh(mission)
-    assert mission.status is MissionStatus.IN_PROGRESS
 
     with pytest.raises(ValueError):
-        mission.transition_to(MissionStatus.DRAFT)
+        mission.start()
+
+    mission.transition_to(MissionStatus.PLANNED)
+    mission.cancel()
+    assert mission.status is MissionStatus.CANCELED
+
+    with pytest.raises(ValueError):
+        mission.transition_to(MissionStatus.CONFIRMED)
+
+
+def test_mission_create_schema_validation():
+    start, end = make_times()
+    payload = MissionCreate(title="Schema", start_time=start, end_time=end)
+
+    assert payload.status is MissionStatus.DRAFT
+
+    with pytest.raises(ValidationError):
+        MissionCreate(title="Schema", start_time=end, end_time=start)
+
+
+def test_mission_update_schema_validation():
+    start, end = make_times()
+    payload = MissionUpdate(start_time=start)
+    assert payload.start_time == start
+    second = MissionUpdate(end_time=end)
+    assert second.end_time == end
+
+    with pytest.raises(ValidationError):
+        MissionUpdate(start_time=start, end_time=start)


### PR DESCRIPTION
## Summary
- introduce the Mission SQLAlchemy model with lifecycle helpers and scheduling constraints
- provide Pydantic schemas for mission payloads with interval validation and transition coverage tests
- create the Alembic migration for missions and update the roadmap to close step 04

## Testing
- pytest --maxfail=1 -q
- pytest --cov=src --cov-report=term-missing
- pwsh -File tools/guards/run_all_guards.ps1 --strict *(fails: `pwsh` is not available in the container)*

Ref: docs/roadmap/step-04.md

------
https://chatgpt.com/codex/tasks/task_e_68d1565bd05c8330b384003a81f21a64