### PR TITLE
chore(ci): harden roadmap ref fixer

### DIFF
--- a/.github/workflows/auto_ref_fix.yml
+++ b/.github/workflows/auto_ref_fix.yml
@@ -1,0 +1,27 @@
+name: auto-ref-fix
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - '**'
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ensure-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup PowerShell 7
+        uses: PowerShell/PowerShell@v1
+        with:
+          pwsh-version: '7.4.x'
+      - name: Ensure roadmap Refs
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pwsh -File tools/codex/fix_roadmap_ref.ps1 -Step auto -CreatePrIfMissing

--- a/tools/codex/fix_roadmap_ref.ps1
+++ b/tools/codex/fix_roadmap_ref.ps1
@@ -10,6 +10,27 @@ function Info($m){ Write-Host "[INFO] $m" }
 function Warn($m){ Write-Host "[WARN] $m" }
 function Err ($m){ Write-Host "[ERR ] $m" }
 
+$script:SummaryItems = @()
+function Add-Summary {
+  param([string]$Message)
+  if ($null -eq $script:SummaryItems) { $script:SummaryItems = @() }
+  $script:SummaryItems += $Message
+}
+
+function Normalize-StepToken {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
+
+  $match = [regex]::Match($Value, "step[-_]?(?<n>\\d{1,2})", 'IgnoreCase')
+  if ($match.Success) { return "{0:D2}" -f ([int]$match.Groups['n'].Value) }
+
+  $generic = [regex]::Match($Value, "(?<!\\d)(?<n>\\d{1,2})(?!\\d)")
+  if ($generic.Success) { return "{0:D2}" -f ([int]$generic.Groups['n'].Value) }
+
+  return $null
+}
+
 # Detect branch & repo
 $branch = (git rev-parse --abbrev-ref HEAD).Trim()
 if ([string]::IsNullOrWhiteSpace($Repo)) {
@@ -33,14 +54,32 @@ $existingSteps = $existingSteps | Sort-Object -Unique
 # Detect current step
 function Detect-Step {
   param([string]$Fallback)
-  if ($Step -ne "auto") { return $Step }
 
-  if ($env:STEP -match "^(\\d{2})$") { return $Matches[1] }
-  if ($branch -match "step[-_](\\d{2})") { return $Matches[1] }
+  if ($Step -ne "auto") {
+    $normalized = Normalize-StepToken $Step
+    if ($normalized) { return $normalized }
+    throw "Unable to understand step value '$Step'. Use NN (e.g. 04)."
+  }
 
-  # look into recent commits for a Ref line
-  $lastN = (git log -n 20 --pretty=%B) -join "\n"
-  if ($lastN -match "Ref:\\s+docs/roadmap/step-(\\d{2})\\.md") { return $Matches[1] }
+  $envStep = Normalize-StepToken $env:STEP
+  if ($envStep) { return $envStep }
+
+  $branchStep = Normalize-StepToken $branch
+  if ($branchStep) { return $branchStep }
+
+  $gitLogLines = @()
+  try { $gitLogLines = git log -n 20 --pretty=%B 2>$null } catch { $gitLogLines = @() }
+  $joined = ($gitLogLines | Where-Object { $_ -ne $null }) -join "`n"
+  if ($joined) {
+    $refMatches = [regex]::Matches($joined, "docs/roadmap/step-(?<n>\\d{1,})\\.md", 'IgnoreCase')
+    if ($refMatches.Count -gt 0) {
+      $lastMatch = $refMatches[$refMatches.Count-1]
+      return "{0:D2}" -f ([int]$lastMatch.Groups['n'].Value)
+    }
+
+    $genericMatch = Normalize-StepToken $joined
+    if ($genericMatch) { return $genericMatch }
+  }
 
   if ($existingSteps.Count -gt 0) { return "{0:D2}" -f ($existingSteps | Select-Object -Last 1) }
 
@@ -66,6 +105,7 @@ if (-not (Test-Path $refRel)) {
   ) | Set-Content -Path $refRel -Encoding UTF8
   git add $refRel
   git commit -m "chore(roadmap): add placeholder for step $curStep`n`nRef: $refRel" | Out-Null
+  Add-Summary "Created placeholder file $refRel and committed it."
 }
 
 # Compute all Ref lines based on existing files (+ current)
@@ -74,7 +114,9 @@ $existingSteps = $existingSteps | Sort-Object -Unique
 $allRefLines = $existingSteps | ForEach-Object { "Ref: docs/roadmap/step-{0:D2}.md" -f $_ }
 
 # Ensure last commit contains the needed Ref(s)
-$lastMsg = (git log -1 --pretty=%B)
+$lastMsgLines = @()
+try { $lastMsgLines = git log -1 --pretty=%B 2>$null } catch { $lastMsgLines = @() }
+$lastMsg = ($lastMsgLines | Where-Object { $_ -ne $null }) -join "`n"
 if ($Mode -eq "all") {
   $missing = @()
   foreach($r in $allRefLines){ if ($lastMsg -notmatch [regex]::Escape($r)) { $missing += $r } }
@@ -82,11 +124,13 @@ if ($Mode -eq "all") {
     Info "Adding empty commit with ALL missing Ref lines."
     $body = "chore(roadmap): ensure all roadmap Refs`n`n" + ($missing -join "`n")
     git commit --allow-empty -m $body | Out-Null
+    Add-Summary "Created empty commit adding missing Ref lines: $($missing -join ', ')."
   } else { Info "Last commit already has all Ref lines." }
 } else {
   if ($lastMsg -notmatch [regex]::Escape("Ref: $refRel")) {
     Info "Adding empty commit with current step Ref line."
     git commit --allow-empty -m "chore(step-$curStep): ensure roadmap Ref`n`nRef: $refRel" | Out-Null
+    Add-Summary "Created empty commit ensuring Ref: $refRel."
   } else { Info "Last commit already contains the current step Ref line." }
 }
 
@@ -97,14 +141,17 @@ function Ensure-Pr-Body {
   $gh = (Get-Command gh -ErrorAction SilentlyContinue)
   if ($gh) {
     Info "gh CLI detected. Checking PR..."
-    $prNumber = (gh pr view --json number -q .number 2>$null)
+    $prNumber = $null
+    try { $prNumber = gh pr view --json number -q .number 2>$null } catch { $prNumber = $null }
     if (-not $prNumber) {
       if ($CreatePrIfMissing) {
         Info "No PR found. Creating one via gh.";
         gh pr create --fill --base main --head $branch | Out-Null
-        $prNumber = (gh pr view --json number -q .number)
+        $prNumber = gh pr view --json number -q .number
+        Add-Summary "Created pull request for branch $branch via gh CLI."
       } else {
         Warn "No PR detected. Skipping PR body update."
+        Add-Summary "PR body not updated (no PR associated with branch $branch)."
         return
       }
     }
@@ -117,6 +164,7 @@ function Ensure-Pr-Body {
       $tmp = New-TemporaryFile
       Set-Content -Path $tmp -Value $newBody -Encoding UTF8
       gh pr edit $prNumber --body-file $tmp | Out-Null
+      Add-Summary "Updated PR #$prNumber body via gh with lines: $($toAdd -join ', ')."
     } else { Info "PR body already contains all Ref lines." }
     return
   }
@@ -124,36 +172,91 @@ function Ensure-Pr-Body {
   $token = $env:GITHUB_TOKEN
   if ($token) {
     Info "gh not found. Trying REST API (GITHUB_TOKEN present)."
-    $prsJson = curl -s -H "Authorization: Bearer $token" -H "Accept: application/vnd.github+json" `
-      "https://api.github.com/repos/$Repo/pulls?head=$Repo:$branch&state=open"
-    $prs = $null; try { $prs = $prsJson | ConvertFrom-Json } catch {}
-    if (-not $prs -or $prs.Count -eq 0) { Warn "No open PR found for $branch. Skipping PR body update."; return }
-    $pr = $prs[0]
+    $headers = @{ Authorization = "Bearer $token"; Accept = "application/vnd.github+json" }
+    $uri = "https://api.github.com/repos/$Repo/pulls?head=$Repo:$branch&state=open"
+    $prs = $null
+    try { $prs = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers } catch {}
+    if (-not $prs -or $prs.Count -eq 0) {
+      Warn "No open PR found for $branch. Skipping PR body update."
+      Add-Summary "PR body not updated via API (no open PR for branch $branch)."
+      return
+    }
+    $pr = if ($prs -is [System.Array]) { $prs[0] } else { $prs }
     $body = $pr.body
-    foreach($r in $RefLines){ if (-not ($body -match [regex]::Escape($r))) { $body = if ($body) { "$body`n`n$r" } else { $r } } }
+    $added = @()
+    foreach($r in $RefLines){ if (-not ($body -match [regex]::Escape($r))) { $body = if ($body) { "$body`n`n$r" } else { $r }; $added += $r } }
+    if ($added.Count -eq 0) { Info "PR body already contains all Ref lines."; return }
     $payload = @{ body = $body } | ConvertTo-Json -Compress
-    curl -s -X PATCH -H "Authorization: Bearer $token" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" -d $payload "https://api.github.com/repos/$Repo/pulls/$($pr.number)" | Out-Null
+    $patchUri = "https://api.github.com/repos/$Repo/pulls/$($pr.number)"
+    Invoke-RestMethod -Method Patch -Uri $patchUri -Headers ($headers + @{ "Content-Type" = "application/json" }) -Body $payload | Out-Null
     Info "PR body updated via REST API."
+    Add-Summary "Updated PR #$($pr.number) body via REST API with lines: $($added -join ', ')."
     return
   }
 
   Warn "Cannot update PR body automatically (no gh and no GITHUB_TOKEN). Please add these lines to the PR description:"
   foreach($r in $RefLines){ Write-Host $r }
+  Add-Summary "PR body requires manual update with Ref lines: $($RefLines -join ', ')."
 }
 
 Ensure-Pr-Body -Repo $Repo -RefLines $allRefLines
 
 # Push with SSH->HTTPS fallback
 function Try-Push { try { git push | Out-Null; return $true } catch { return $false } }
-if (-not (Try-Push)){
-  Warn "SSH push failed. Falling back to HTTPS."
-  $originUrl = (git remote get-url origin).Trim()
-  if ($originUrl -match "github.com[:/](?<owner>[^/]+)/(?<name>[^/.]+)(?:\\.git)?") {
-    $owner = $Matches.owner; $name = $Matches.name
-    $https = "https://github.com/$owner/$name.git"
-    git remote set-url origin $https
-    if (-not (Try-Push)) { Err "HTTPS push also failed. Check network/credentials."; exit 2 }
-  } else { Err "Cannot parse origin to switch to HTTPS."; exit 3 }
+$eventName = $env:GITHUB_EVENT_NAME
+$runningInActions = $env:GITHUB_ACTIONS -eq "true"
+$skipPush = $false
+if ($runningInActions -and $eventName -and $eventName -like "pull_request*") {
+  Warn "Skipping git push because workflow is running for $eventName (write permissions may be restricted)."
+  Add-Summary "Push skipped (GitHub Actions $eventName run)."
+  $skipPush = $true
+}
+
+if (-not $skipPush) {
+  $usedFallback = $false
+  $pushed = Try-Push
+  if (-not $pushed) {
+    Warn "SSH push failed. Falling back to HTTPS."
+    $originUrl = (git remote get-url origin).Trim()
+    if ($originUrl -match "github.com[:/](?<owner>[^/]+)/(?<name>[^/.]+)(?:\\.git)?") {
+      $owner = $Matches.owner; $name = $Matches.name
+      $https = "https://github.com/$owner/$name.git"
+      git remote set-url origin $https
+      $usedFallback = $true
+      $pushed = Try-Push
+    } else {
+      if ($runningInActions) {
+        Warn "Cannot parse origin to switch to HTTPS. Skipping fallback in CI."
+        Add-Summary "Push failed: could not parse origin URL for HTTPS fallback."
+      } else {
+        Err "Cannot parse origin to switch to HTTPS."
+        exit 3
+      }
+    }
+  }
+
+  if ($pushed) {
+    if ($usedFallback) {
+      Add-Summary "Pushed changes via HTTPS fallback."
+    } else {
+      Add-Summary "Pushed changes using existing remote configuration."
+    }
+  } else {
+    if ($runningInActions) {
+      Warn "HTTPS push also failed (likely due to limited credentials). Please push manually."
+      Add-Summary "Push failed in CI. Please push manually with required credentials."
+    } else {
+      Err "HTTPS push also failed. Check network/credentials."
+      exit 2
+    }
+  }
 }
 
 Info "Done. Commit and PR body now satisfy roadmap guard for current and all steps."
+
+Info "Summary:"
+if ($script:SummaryItems.Count -gt 0) {
+  foreach($item in $script:SummaryItems){ Info "  - $item" }
+} else {
+  Info "  No updates were necessary."
+}


### PR DESCRIPTION
## Summary
- expand the PowerShell roadmap ref fixer to auto-detect step numbers more robustly, add detailed summaries, and gracefully handle CI push limitations
- add GitHub Actions workflow that runs the fixer on push and pull_request events with PowerShell 7.4

## Testing
- pytest *(fails: missing httpx dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1600dff4c833082256c50ea04bbb0