### PR TITLE
Fix guard automation and document roadmap remediation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,12 @@
-# Pull Request Template
+## Summary
+-
 
+## Testing
+-
+
+## Roadmap Reference (required)
 Ref: docs/roadmap/step-XX.md
 
 ## Checklist
-- [ ] Tests pass in CI
-- [ ] Lint and type checks pass
-- [ ] Documentation updated if needed
-- [ ] Commit message follows Conventional Commits
-- [ ] PR description includes Ref: docs/roadmap/step-XX.md
-- [ ] docs/codex/last_output.json present with a non-empty "summary"
-
-## Description
-Clearly explain the problem and the proposed solution.
-
-## Why
-Describe why this change is necessary.
-
-## What changed
-List the files, workflows, or guards that were updated.
-
-### Quick command to generate last_output.json
-```
-pwsh -File tools/codex/ensure_last_output.ps1 -Step "XX" -Title "Step XX - Snapshot" -Summary "Short human summary." -Status "success"
-```
+- [ ] I included the correct `Ref:` to the roadmap step.
+- [ ] CI green locally and on GitHub.

--- a/.github/workflows/auto_ref_fix.yml
+++ b/.github/workflows/auto_ref_fix.yml
@@ -16,12 +16,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup PowerShell 7
-        uses: PowerShell/PowerShell@v1
-        with:
-          pwsh-version: '7.4.x'
       - name: Ensure roadmap Refs
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: pwsh -File tools/codex/fix_roadmap_ref.ps1 -Step auto -CreatePrIfMissing
+        run: |
+          pwsh -v
+          pwsh -File tools/codex/fix_roadmap_ref.ps1 -Step auto -CreatePrIfMissing

--- a/.github/workflows/guard-fix.yml
+++ b/.github/workflows/guard-fix.yml
@@ -1,0 +1,48 @@
+name: guard-fix
+on:
+  workflow_dispatch:
+    inputs:
+      step_ref:
+        description: 'Optional roadmap ref override (e.g. docs/roadmap/step-04.md)'
+        required: false
+      amend:
+        description: 'Amend the last commit instead of creating a new one'
+        required: false
+        type: boolean
+      pr_number:
+        description: 'PR number to update (optional, auto-detected when omitted)'
+        required: false
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ensure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Ensure roadmap reference
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        run: |
+          $stepRef = '${{ github.event.inputs.step_ref }}'
+          $amend = '${{ github.event.inputs.amend }}'
+          $args = @()
+          if ($stepRef) {
+            $args += '-StepRef'
+            $args += $stepRef
+          }
+          if ($amend -eq 'true') {
+            $args += '-Amend'
+          }
+          pwsh -v
+          pwsh -File tools/codex/ensure_roadmap_ref.ps1 @args

--- a/docs/guards/README.md
+++ b/docs/guards/README.md
@@ -1,0 +1,28 @@
+# Guards README
+
+This repo enforces a strict roadmap reference policy on every PR.
+
+## Why it fails
+- `roadmap_guard.ps1` scans the PR body and last commit message.
+- If neither contains a line exactly like: `Ref: docs/roadmap/step-XX.md`, the guard fails.
+
+## Quick fix (local)
+1) Decide the step file you are implementing, e.g. `docs/roadmap/step-04.md`.
+2) Run:
+
+   pwsh -File tools/codex/ensure_roadmap_ref.ps1 -StepRef "docs/roadmap/step-04.md"
+
+3) Push the branch and re-run CI.
+
+## Quick fix (on GitHub UI)
+- Edit the PR description and add a line at the end:
+
+  Ref: docs/roadmap/step-04.md
+
+## Prevention
+- Use the PR template; keep the `Ref:` line updated when you change steps.
+- Commit messages for roadmap work should include the `Ref:` line.
+
+## Runner notes
+- We run guards on `ubuntu-latest` with PowerShell Core using `shell: pwsh`.
+- Do not use `powershell/powershell@v1` or `actions/setup-powershell`.

--- a/tools/codex/ensure_roadmap_ref.ps1
+++ b/tools/codex/ensure_roadmap_ref.ps1
@@ -1,0 +1,79 @@
+param(
+  [string]$StepRef,
+  [switch]$Amend
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-StepRef {
+  param([string]$InputRef)
+  if ($InputRef) { return $InputRef }
+  $docs = Get-ChildItem -Path "docs/roadmap" -Filter "step-*.md" -File | Sort-Object Name
+  if (-not $docs) { throw "No roadmap step files under docs/roadmap" }
+  $last = $docs[-1].Name
+  return ("docs/roadmap/{0}" -f $last)
+}
+
+$refPath = Resolve-StepRef -InputRef $StepRef
+$refLine = "Ref: $refPath"
+
+# Try to update PR body (if gh is available and we are on a PR context)
+$prNumber = $env:PR_NUMBER
+if (-not $prNumber) {
+  try {
+    $prNumber = gh pr view --json number -q .number
+  } catch {}
+}
+
+if ($prNumber) {
+  try {
+    $body = gh pr view $prNumber --json body -q .body
+    if ($body -notmatch "(?m)^Ref:\s*") {
+      $newBody = "$body`n`n$refLine"
+      gh pr edit $prNumber --body "$newBody" | Out-Null
+      Write-Host "Injected Ref into PR body: $refLine"
+      exit 0
+    }
+  } catch {}
+}
+
+# Fallback: ensure last commit message contains the Ref line
+$needCommit = $true
+try {
+  $lastMsg = git log -1 --pretty=%B
+  if ($lastMsg -match "(?m)^Ref:\s*") { $needCommit = $false }
+} catch {}
+
+if ($needCommit) {
+  $msg = "chore(ci): add roadmap reference`n`n$refLine"
+  if ($Amend) {
+    git commit --allow-empty --amend -m "$msg"
+  } else {
+    git commit --allow-empty -m "$msg"
+  }
+  Write-Host "Created commit with Ref line: $refLine"
+}
+
+# Push with SSH, then fallback to HTTPS if SSH fails
+function Push-With-Fallback {
+  param([string]$Branch)
+  try {
+    git push origin $Branch
+    return
+  } catch {
+    Write-Warning "SSH push failed, switching to HTTPS"
+    $origin = git remote get-url origin
+    if ($origin -match "^git@github.com:(.*)$") {
+      $repo = $Matches[1]
+      git remote set-url origin https://github.com/$repo
+      git push origin $Branch
+      git remote set-url origin $origin
+    } else {
+      throw
+    }
+  }
+}
+
+$branch = git rev-parse --abbrev-ref HEAD
+Push-With-Fallback -Branch $branch


### PR DESCRIPTION
## Summary
- replace the invalid PowerShell setup action with native `shell: pwsh`
- add a roadmap reference remediation script plus a manual guard-fix workflow
- improve guard logging, refresh the PR template, and document roadmap guard expectations

## Testing
- ⚠️ `pwsh -File tools/guards/run_all_guards.ps1` *(fails in container: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1661703308330b2fc05673617c0c6